### PR TITLE
Negate the backdrop when the menu is open

### DIFF
--- a/choonio-ui/src/components/item-grid/menu/ItemGridMenu.tsx
+++ b/choonio-ui/src/components/item-grid/menu/ItemGridMenu.tsx
@@ -124,6 +124,7 @@ export default function ItemGridMenu({ items, anchorEl, open, onClose }: ItemGri
             onClose={handleClose}
             keepMounted
             onClick={ignoreClick}
+            BackdropProps={{ style: { opacity: 0 } }}
         >
             {components}
         </Menu>


### PR DESCRIPTION
There is no reason to blur the page (via the partially opaque backdrop overlay) when opening a menu.