### PR TITLE
Basic support for audio equalizer

### DIFF
--- a/choonio-core/src/main/java/uk/co/caprica/choonio/api/endpoints/EqualizerController.java
+++ b/choonio-core/src/main/java/uk/co/caprica/choonio/api/endpoints/EqualizerController.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of Choonio.
+ *
+ * Choonio is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Choonio is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Choonio.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package uk.co.caprica.choonio.api.endpoints;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Mono;
+import uk.co.caprica.choonio.api.model.equalizer.EqualizerPreset;
+import uk.co.caprica.choonio.api.model.equalizer.EqualizerState;
+import uk.co.caprica.choonio.api.model.request.EnableEqualizerRequest;
+import uk.co.caprica.choonio.api.model.request.SetEqualizerRequest;
+import uk.co.caprica.choonio.mediaplayer.PlayerComponent;
+import uk.co.caprica.vlcj.player.base.Equalizer;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("equalizer")
+@RequiredArgsConstructor
+@Slf4j
+public class EqualizerController {
+
+    private final PlayerComponent playerComponent;
+
+    @GetMapping
+    public Mono<EqualizerState> getEqualizerState() {
+        log.info("getEqualizerState()");
+        Equalizer equalizer = playerComponent.getEqualizer();
+        if (equalizer != null) {
+            return Mono.just(new EqualizerState(equalizer.preamp(), equalizer.amps()));
+        } else {
+            return Mono.error(new ResponseStatusException(HttpStatus.NO_CONTENT, "Equalizer not enabled"));
+        }
+    }
+
+    @PutMapping
+    public void enableEqualizer(@RequestBody EnableEqualizerRequest enableEqualizerRequest) {
+        log.info("enableEqualizer(enableEqualizerRequest={})", enableEqualizerRequest);
+        playerComponent.enableEqualizer(enableEqualizerRequest.isEnable());
+    }
+
+    @PutMapping("amps")
+    public void setEqualizer(@RequestBody SetEqualizerRequest setEqualizerRequest) {
+        log.info("setEqualizerRequest(setEqualizerRequest={})", setEqualizerRequest);
+        playerComponent.setEqualizer(setEqualizerRequest.getPreamp(), setEqualizerRequest.getBands());
+    }
+
+    @GetMapping("presets")
+    public Mono<List<EqualizerPreset>> getPresets() {
+        log.info("getPresets()");
+        return Mono.just(playerComponent.getEqualizerPresets());
+    }
+}

--- a/choonio-core/src/main/java/uk/co/caprica/choonio/api/model/equalizer/EqualizerPreset.java
+++ b/choonio-core/src/main/java/uk/co/caprica/choonio/api/model/equalizer/EqualizerPreset.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of Choonio.
+ *
+ * Choonio is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Choonio is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Choonio.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package uk.co.caprica.choonio.api.model.equalizer;
+
+import lombok.Value;
+
+@Value
+public class EqualizerPreset {
+    String name;
+    float preamp;
+    float[] bands;
+}

--- a/choonio-core/src/main/java/uk/co/caprica/choonio/api/model/equalizer/EqualizerState.java
+++ b/choonio-core/src/main/java/uk/co/caprica/choonio/api/model/equalizer/EqualizerState.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of Choonio.
+ *
+ * Choonio is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Choonio is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Choonio.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package uk.co.caprica.choonio.api.model.equalizer;
+
+import lombok.Value;
+
+@Value
+public class EqualizerState {
+    float preamp;
+    float[] bands;
+}

--- a/choonio-core/src/main/java/uk/co/caprica/choonio/api/model/request/EnableEqualizerRequest.java
+++ b/choonio-core/src/main/java/uk/co/caprica/choonio/api/model/request/EnableEqualizerRequest.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of Choonio.
+ *
+ * Choonio is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Choonio is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Choonio.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package uk.co.caprica.choonio.api.model.request;
+
+import lombok.Value;
+
+@Value
+public class EnableEqualizerRequest {
+    boolean enable;
+}

--- a/choonio-core/src/main/java/uk/co/caprica/choonio/api/model/request/SetEqualizerRequest.java
+++ b/choonio-core/src/main/java/uk/co/caprica/choonio/api/model/request/SetEqualizerRequest.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of Choonio.
+ *
+ * Choonio is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Choonio is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Choonio.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package uk.co.caprica.choonio.api.model.request;
+
+import lombok.Value;
+
+@Value
+public class SetEqualizerRequest {
+    float preamp;
+    float[] bands;
+}

--- a/choonio-core/src/main/java/uk/co/caprica/choonio/mediaplayer/PlayerComponent.java
+++ b/choonio-core/src/main/java/uk/co/caprica/choonio/mediaplayer/PlayerComponent.java
@@ -195,8 +195,7 @@ public class PlayerComponent extends BaseReadWriteLock {
 
     public void setEqualizer(float preamp, float[] bands) {
         log.info("setEqualizer(preamp={}, bands={})", preamp, Arrays.toString(bands));
-        equalizer.setPreamp(preamp);
-        equalizer.setAmps(bands);
+        equalizer.setAmps(preamp, bands);
     }
 
     public List<EqualizerPreset> getEqualizerPresets() {

--- a/choonio-ui/src/api/endpoints/equalizer-controller.ts
+++ b/choonio-ui/src/api/endpoints/equalizer-controller.ts
@@ -1,0 +1,66 @@
+/*
+ * This file is part of Choonio.
+ *
+ * Choonio is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Choonio is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Choonio.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import axios from 'axios'
+import { useMutation, useQuery, useQueryClient } from 'react-query'
+import { equalizerPresetsUrl, equalizerAmpsUrl, equalizerUrl } from '../../config/service-endpoints'
+import { EnableEqualizerRequest, EqualizerPresetData, EqualizerStateData, SetEqualizerRequest } from '../model/equalizer-model'
+
+const STATE_QUERY_ID = 'equalizer-state'
+const PRESETS_QUERY_ID = 'equalizer-presets'
+
+const getEqualizerState = async () => {
+    const { data } = await axios.get(equalizerUrl())
+    return data
+}
+
+const putEqualizerEnable = async (enableEqualizerRequest: EnableEqualizerRequest) => {
+    await axios.put(equalizerUrl(), enableEqualizerRequest)
+}
+
+const putEqualizerAmps = async (setEqualizerRequest: SetEqualizerRequest) => {
+    await axios.put(equalizerAmpsUrl(), setEqualizerRequest)
+}
+
+const getEqualizerPresets = async () => {
+    const { data } = await axios.get(equalizerPresetsUrl())
+    return data
+}
+
+export const useGetEqualizerState = () => {
+    return useQuery<EqualizerStateData, Error>(STATE_QUERY_ID, () => getEqualizerState())
+}
+
+export const useEnableEqualizer = () => {
+    const mutator = useMutation(putEqualizerEnable)
+    return (enable: boolean, onSuccess?: () => void) => mutator.mutate({ enable }, { onSuccess })
+}
+
+export const useSetEqualizer = () => {
+    const mutator = useMutation(putEqualizerAmps)
+    return (setEqualizerRequest: SetEqualizerRequest, onSuccess?: () => void) =>
+        mutator.mutate(setEqualizerRequest, { onSuccess })
+}
+
+export const useGetEqualizerPresets = () => {
+    return useQuery<EqualizerPresetData[], Error>(PRESETS_QUERY_ID, () => getEqualizerPresets())
+}
+
+export const useInvalidateEqualizerState = () => {
+    const queryClient = useQueryClient()
+    return () => queryClient.invalidateQueries(STATE_QUERY_ID)
+}

--- a/choonio-ui/src/api/model/equalizer-model.ts
+++ b/choonio-ui/src/api/model/equalizer-model.ts
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Choonio.
+ *
+ * Choonio is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Choonio is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Choonio.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+export interface EqualizerStateData {
+    readonly preamp: number
+    readonly bands: Array<number>
+}
+
+export interface EnableEqualizerRequest {
+    readonly enable: boolean
+}
+
+export interface SetEqualizerRequest {
+    readonly preamp: number
+    readonly bands: Array<number>
+}
+
+export interface EqualizerPresetData {
+    readonly name: string
+    readonly preamp: number
+    readonly bands: Array<number>
+}

--- a/choonio-ui/src/components/drawers/navigation/NavigationDrawer.tsx
+++ b/choonio-ui/src/components/drawers/navigation/NavigationDrawer.tsx
@@ -24,7 +24,7 @@ import List from '@mui/material/List'
 import Toolbar from '@mui/material/Toolbar'
 import Typography from '@mui/material/Typography'
 
-import { MdFavorite, MdHelp, MdImage, MdViewList } from 'react-icons/md'
+import { MdEqualizer, MdFavorite, MdHelp, MdImage, MdViewList } from 'react-icons/md'
 import { MdHistory } from 'react-icons/md'
 import { MdHome } from 'react-icons/md'
 import { MdLibraryMusic } from 'react-icons/md'
@@ -69,6 +69,7 @@ export default function NavigationDrawer({ open, onClose }: NavigationDrawerProp
         gotoFavourites,
         gotoStatistics,
         gotoSettings,
+        gotoEqualizer,
         gotoVisualisation,
         gotoAbout
     } = useNavigation()
@@ -110,6 +111,7 @@ export default function NavigationDrawer({ open, onClose }: NavigationDrawerProp
                     <Divider />
                     <NavigationDrawerListItem icon={MdImage} text='Visualisation' onClick={select(gotoVisualisation)} />
                     <Divider />
+                    <NavigationDrawerListItem icon={MdEqualizer} text='Audio Equalizer' onClick={select(gotoEqualizer)} />
                     <NavigationDrawerListItem icon={MdSettings} text='Settings' onClick={select(gotoSettings)} />
                     <NavigationDrawerListItem icon={MdHelp} text='Help &amp; feedback' onClick={select(gotoAbout)} />
                 </List>

--- a/choonio-ui/src/config/service-endpoints.ts
+++ b/choonio-ui/src/config/service-endpoints.ts
@@ -148,6 +148,18 @@ export function playerControlsUrl() {
     return '/api/player/controls'
 }
 
+export function equalizerUrl() {
+    return '/api/equalizer'
+}
+
+export function equalizerAmpsUrl() {
+    return '/api/equalizer/amps'
+}
+
+export function equalizerPresetsUrl() {
+    return '/api/equalizer/presets'
+}
+
 export function rateTrackUrl(artist: string, album: string, track: string) {
     return `/api/ratings/${encodeURIComponent(artist)}/${encodeURIComponent(album)}/${encodeURIComponent(track)}`
 }

--- a/choonio-ui/src/hooks/navigation/useNavigation.tsx
+++ b/choonio-ui/src/hooks/navigation/useNavigation.tsx
@@ -45,8 +45,9 @@ export const useNavigation = () => {
     const gotoQueue = () => history.push('/queue')
     const gotoRecent = () => history.push('/recent')
     const gotoFavourites = () => history.push('/favourites')
-    const gotoGenres = () => history.push('genres')
+    const gotoGenres = () => history.push('/genres')
     const gotoStatistics = () => history.push('/stats')
+    const gotoEqualizer = () => history.push('/equalizer')
     const gotoVisualisation = () => history.push('/visualisation')
     const gotoSettings = () => history.push('/settings')
     const gotoAbout = () => history.push('/about')
@@ -95,6 +96,7 @@ export const useNavigation = () => {
         gotoGenres,
         gotoMedia,
         gotoStatistics,
+        gotoEqualizer,
         gotoVisualisation,
         gotoSettings,
         gotoAbout,

--- a/choonio-ui/src/main/MainContent.tsx
+++ b/choonio-ui/src/main/MainContent.tsx
@@ -24,6 +24,7 @@ import AlbumPage from '../ui/pages/album/AlbumPage'
 import ArtistPage from '../ui/pages/artist/ArtistPage'
 import ArtistsPage from '../ui/pages/artists/ArtistsPage'
 import EditPlaylistPage from '../ui/pages/playlist-edit/EditPlaylistPage'
+import EqualizerPage from '../ui/pages/equalizer/EqualizerPage'
 import ExpoPage from '../ui/pages/expo/ExpoPage'
 import FavouritesPage from '../ui/pages/favourites/FavouritesPage'
 import HomePage from '../ui/pages/home/HomePage'
@@ -59,6 +60,7 @@ export default function MainContent() {
             <TransitionRoute path='/favourites' component={FavouritesPage} />
             <TransitionRoute path='/playlists' component={PlaylistsPage} />
             <TransitionRoute path='/recent' component={RecentsPage} />
+            <TransitionRoute path='/equalizer' component={EqualizerPage} />
             <TransitionRoute component={NotFoundPage} />
         </Switch>
     )

--- a/choonio-ui/src/ui/pages/equalizer/AmplificationControl.tsx
+++ b/choonio-ui/src/ui/pages/equalizer/AmplificationControl.tsx
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Choonio.
+ *
+ * Choonio is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Choonio is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Choonio.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import clsx from 'clsx'
+import { Slider } from '@mui/material'
+import makeStyles from '@mui/styles/makeStyles'
+
+const MIN_AMP = -20
+const MAX_AMP = 20
+
+const useStyles = makeStyles(theme => ({
+    root: {
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center'
+    },
+    placeholder: {
+        padding: theme.spacing(1)
+    },
+    slider: {},
+    label: {
+        marginTop: theme.spacing(2)
+    },
+    value: {
+        marginTop: theme.spacing(1)
+    }
+}))
+
+interface AmplificationControlProps {
+    className?: string
+    disabled?: boolean
+    label: string
+    value: number
+    onChange: (value: number) => void
+    onChangeCommitted: () => void
+}
+
+export default function AmplificationControl({
+    className,
+    disabled,
+    label,
+    value,
+    onChange,
+    onChangeCommitted
+}: AmplificationControlProps) {
+    const classes = useStyles()
+
+    const handleChange = (_event: Event, newValue: number | number[]) => onChange(newValue as number)
+
+    const handleChangeCommitted = () => onChangeCommitted()
+
+    return (
+        <div className={clsx(className, classes.root)}>
+            <Slider
+                className={classes.slider}
+                disabled={disabled}
+                orientation='vertical'
+                value={value}
+                min={MIN_AMP}
+                max={MAX_AMP}
+                onChange={handleChange}
+                onChangeCommitted={handleChangeCommitted}
+            />
+            <div className={classes.label}>{label}</div>
+            <div className={classes.value}>{value.toFixed(1)} dB</div>
+        </div>
+    )
+}

--- a/choonio-ui/src/ui/pages/equalizer/EqualizerPage.tsx
+++ b/choonio-ui/src/ui/pages/equalizer/EqualizerPage.tsx
@@ -1,0 +1,183 @@
+/*
+ * This file is part of Choonio.
+ *
+ * Choonio is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Choonio is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Choonio.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import makeStyles from '@mui/styles/makeStyles'
+import { equalizerBandNames } from './equalizer'
+import {
+    useEnableEqualizer,
+    useGetEqualizerPresets,
+    useGetEqualizerState,
+    useInvalidateEqualizerState,
+    useSetEqualizer
+} from '../../../api/endpoints/equalizer-controller'
+import AmplificationControl from './AmplificationControl'
+import { ChangeEvent, useEffect, useState } from 'react'
+import {
+    Checkbox,
+    Container,
+    Divider,
+    FormControl,
+    FormControlLabel,
+    InputLabel,
+    MenuItem,
+    Paper,
+    Select,
+    SelectChangeEvent,
+    Typography
+} from '@mui/material'
+import GroupHeading from '../../components/group/GroupHeading'
+import { EqualizerPresetData } from '../../../api/model/equalizer-model'
+
+const zeroBands = () => Array(equalizerBandNames.length).fill(0)
+
+const useStyles = makeStyles(theme => ({
+    root: {},
+    content: {
+        padding: theme.spacing(4, 8),
+        display: 'flex',
+        flexDirection: 'column'
+    },
+    controls: {
+        display: 'flex',
+        alignItems: 'center'
+    },
+    amps: {
+        display: 'grid',
+        gridTemplateColumns: 'repeat(12, 56px)',
+        gridTemplateRows: '300px',
+        justifyItems: 'center',
+        marginTop: theme.spacing(4)
+    },
+    amp: {},
+    divider: {
+        margin: 0,
+        padding: 0
+    }
+}))
+
+export default function EqualizerPage() {
+    const classes = useStyles()
+
+    const [enable, setEnable] = useState(false)
+    const [preset, setPreset] = useState('')
+    const [preamp, setPreamp] = useState(0)
+    const [bands, setBands] = useState(zeroBands())
+
+    const { data: equalizerState } = useGetEqualizerState()
+    const { data: presets } = useGetEqualizerPresets()
+    const enableEqualizer = useEnableEqualizer()
+    const setEqualizer = useSetEqualizer()
+    const invalidateEqualizerState = useInvalidateEqualizerState()
+
+    useEffect(() => {
+        if (equalizerState) {
+            setEnable(true)
+            setPreamp(equalizerState.preamp)
+            setBands(equalizerState.bands)
+        } else {
+            setEnable(false)
+            setPreamp(0)
+            setBands(zeroBands())
+        }
+    }, [equalizerState])
+
+    const handleChangeEnable = (event: ChangeEvent<HTMLInputElement>) => {
+        const newEnabled = event.target.checked
+        setEnable(newEnabled)
+        enableEqualizer(newEnabled, () => invalidateEqualizerState())
+    }
+
+    const handleChangePreset = (event: SelectChangeEvent) => {
+        if (presets) {
+            const presetName = event.target.value
+            setPreset(presetName)
+            const preset = presets.find((p: EqualizerPresetData) => p.name === presetName)
+            let newPreamp
+            let newBands
+            if (preset) {
+                newPreamp = preset.preamp
+                newBands = [...preset.bands]
+            } else {
+                newPreamp = 0
+                newBands = zeroBands()
+            }
+            setPreamp(newPreamp)
+            setBands(newBands)
+            applyEqualizer(newPreamp, newBands)
+        }
+    }
+
+    const handleChangePreamp = (newValue: number) => setPreamp(newValue)
+
+    const handleChangeCommittedPreamp = () => applyEqualizer(preamp, bands)
+
+    const handleChangeAmp = (index: number) => (newValue: number) => {
+        const newValues = [...bands]
+        newValues[index] = newValue
+        setBands(newValues)
+    }
+
+    const handleChangeCommittedAmp = (_index: number) => () => applyEqualizer(preamp, bands)
+
+    const applyEqualizer = (newPreamp: number, newBands: Array<number>) => setEqualizer({ preamp: newPreamp, bands: newBands })
+
+    return (
+        <Container className={classes.root} maxWidth='sm'>
+            <GroupHeading caption='Audio Equalizer' />
+            <Paper className={classes.content}>
+                <div className={classes.controls}>
+                    <FormControlLabel control={<Checkbox checked={enable} onChange={handleChangeEnable} />} label='Enable' />
+                    <InputLabel id='preset-label' style={{ marginLeft: 16 }}>
+                        <Typography variant='body1'>Preset</Typography>
+                    </InputLabel>
+                    <FormControl variant='standard' sx={{ m: 1, minWidth: 120 }}>
+                        <Select labelId='preset-label' label='PresetX' value={preset} onChange={handleChangePreset}>
+                            <MenuItem value=''>None</MenuItem>
+                            {presets?.map(preset => (
+                                <MenuItem key={preset.name} value={preset.name}>
+                                    {preset.name}
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </FormControl>
+                </div>
+                <Divider />
+                <div className={classes.amps}>
+                    <AmplificationControl
+                        disabled={!enable}
+                        label='Preamp'
+                        value={preamp}
+                        onChange={handleChangePreamp}
+                        onChangeCommitted={handleChangeCommittedPreamp}
+                    />
+                    <Divider className={classes.divider} orientation='vertical' />
+                    {equalizerBandNames.map((band, index) => (
+                        <AmplificationControl
+                            className={classes.amp}
+                            key={band}
+                            disabled={!enable}
+                            label={band}
+                            value={bands[index]}
+                            onChange={handleChangeAmp(index)}
+                            onChangeCommitted={handleChangeCommittedAmp(index)}
+                        />
+                    ))}
+                </div>
+            </Paper>
+        </Container>
+    )
+}

--- a/choonio-ui/src/ui/pages/equalizer/equalizer.ts
+++ b/choonio-ui/src/ui/pages/equalizer/equalizer.ts
@@ -1,0 +1,18 @@
+/*
+ * This file is part of Choonio.
+ *
+ * Choonio is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Choonio is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Choonio.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+export const equalizerBandNames = ['60 Hz', '170 Hz', '310 Hz', '600 Hz', '1 KHz', '3 KHz', '6 KHz', '12 Khz', '14 Khz', '16 KHz']


### PR DESCRIPTION
Allows for selection of the standard presets and for editing of
preamp and each equalizer band.

No persistence of settings yet, nor any support for saving or
loading user presets.