### PR TITLE
Add a (commented) attribute to set opacity for menu backdrop props

### DIFF
--- a/choonio-ui/src/ui/components/group/GroupMenu.tsx
+++ b/choonio-ui/src/ui/components/group/GroupMenu.tsx
@@ -60,6 +60,7 @@ export default function GroupMenu<T extends string | number>({
             keepMounted
             open={Boolean(anchorEl)}
             onClose={onClose}
+            // BackdropProps={{ style: { opacity: 0 } }}
             TransitionProps={{ onExited: handleExit }}
             classes={{ list: classes.menu }}
         >


### PR DESCRIPTION
In most cases, the opacity of the page background overlay is set to
0 for things like active menus or active drawers.

However, in this case it seems better to keep the background overlay
opacity.

Nevertheless, adding the commented out attribute for simplicity if
this is switched in the future.