### PR TITLE
Do not hardcode server sent event end-points (as much)

### DIFF
--- a/choonio-ui/src/config/service-endpoints.ts
+++ b/choonio-ui/src/config/service-endpoints.ts
@@ -186,4 +186,4 @@ export function listensByArtistUrl(minimumListens: number, fromDateInclusive?: s
     return url
 }
 
-export const eventsUrl = () => 'http://localhost:8080/api/events'
+export const eventsUrl = () => `${window.location.protocol}//${window.location.hostname}:8080/api/events`


### PR DESCRIPTION
Local running on port 3000 breaks with server sent events, it does
not proxy the requests to port 8080 (as per package.json).

This is why the URL was hard-coded to localhost:8080.

This means the application could only run on localhost, not from
some other device on the network.

Consequently, dynamically construct the URL using the various
components from "window.location".

This is still not ideal, since the port remains hard-coded, but is
good enough for now.