### PR TITLE
Do not refetch highlights on window focus

### DIFF
--- a/choonio-ui/src/api/endpoints/highlights-controller.ts
+++ b/choonio-ui/src/api/endpoints/highlights-controller.ts
@@ -34,7 +34,7 @@ const refreshHighlights = async () => {
 }
 
 export const useGetHighlights = () => {
-    return useQuery<HighlightData[], Error>([QUERY_ID], () => getHighlights())
+    return useQuery<HighlightData[], Error>([QUERY_ID], () => getHighlights(), { refetchOnWindowFocus: false })
 }
 
 export const useRefreshHighlights = () => {


### PR DESCRIPTION
There is no need to refetch these on window focus, they are refreshed
automatically on a timer anyway and we do not want e.g. an extra
refresh if focussing the window immediately prior to the next refresh.