### PR TITLE
Fix back-button navigation on screens with sub-screens

### DIFF
--- a/choonio-ui/src/ui/pages/favourites/FavouritesPage.tsx
+++ b/choonio-ui/src/ui/pages/favourites/FavouritesPage.tsx
@@ -46,7 +46,7 @@ export default function FavouritesPage() {
                 <Route path=':grouping' element={<FavouritesNav />} />
             </Routes>
             <Routes>
-                <Route path='' element={<Navigate to={favouritesGroup} />} />
+                <Route path='' element={<Navigate to={favouritesGroup} replace />} />
                 <Route path=':grouping' element={<Content />} />
             </Routes>
         </Container>

--- a/choonio-ui/src/ui/pages/playlists/PlaylistsPage.tsx
+++ b/choonio-ui/src/ui/pages/playlists/PlaylistsPage.tsx
@@ -49,7 +49,7 @@ export default function PlaylistsPage() {
                 <Route path=':grouping' element={<PlaylistsNav />} />
             </Routes>
             <Routes>
-                <Route path='' element={<Navigate to={playlistsGroup} />} />
+                <Route path='' element={<Navigate to={playlistsGroup} replace />} />
                 <Route path=':grouping' element={<Content />} />
             </Routes>
         </Container>

--- a/choonio-ui/src/ui/pages/recents/RecentsPage.tsx
+++ b/choonio-ui/src/ui/pages/recents/RecentsPage.tsx
@@ -44,7 +44,7 @@ export default function RecentsPage() {
                 <Route path=':grouping' element={<RecentsNav />} />
             </Routes>
             <Routes>
-                <Route path='' element={<Navigate to={recentsGroup} />} />
+                <Route path='' element={<Navigate to={recentsGroup} replace />} />
                 <Route path=':grouping' element={<Content />} />
             </Routes>
         </Container>

--- a/choonio-ui/src/ui/pages/stats/StatsPage.tsx
+++ b/choonio-ui/src/ui/pages/stats/StatsPage.tsx
@@ -28,7 +28,7 @@ export default function StatsPage() {
     return (
         <div>
             <Routes>
-                <Route path='' element={<Navigate to={`top/${topHowMany}`} />} />
+                <Route path='' element={<Navigate to={`top/${topHowMany}`} replace />} />
                 <Route path='top/:top/*' element={<TopStatsPage />} />
             </Routes>
         </div>

--- a/choonio-ui/src/ui/pages/stats/top/TopStatsPage.tsx
+++ b/choonio-ui/src/ui/pages/stats/top/TopStatsPage.tsx
@@ -52,7 +52,7 @@ export default function TopStatsPage() {
                 <Route path=':what/:period' element={<TopStatsNav />} />
             </Routes>
             <Routes>
-                <Route path='' element={<Navigate to={`${topWhat}/${topPeriod}`} />} />
+                <Route path='' element={<Navigate to={`${topWhat}/${topPeriod}`} replace />} />
                 <Route path=':top/artists' element={<Navigate to={`artists/${topPeriod}`} />} />
                 <Route path=':top/albums' element={<Navigate to={`albums/${topPeriod}`} />} />
                 <Route path=':top/tracks' element={<Navigate to={`tracks/${topPeriod}`} />} />


### PR DESCRIPTION
Initially navigating to these screens by default will immediately issue an automatic navigation to the configured sub-screen, this leaves an errant item in the browser history stack.

The problem was that it was not possible to use the back button to navigate back from those pages.

The solution is to use the "replace" option on the Navigate tag used to do the automatic navigation.